### PR TITLE
Update ZooMizer to work with Mizer 2.3.0

### DIFF
--- a/Setup_ZooMizer_grid.R
+++ b/Setup_ZooMizer_grid.R
@@ -65,7 +65,7 @@ ZooMizer_coupled <- function(ID, tmax = 1000, effort = 0) {
   new <- stable_zoo[which(groups$Type == "Zooplankton"),]
   
   temp_eff <- 2.^((input$sst - 30)/10)
-  
+  R_factor = 1.01
   fish_params <- newTraitParams(no_sp = 5,
                                 min_w = 10^(-3),
                                 min_w_inf = 10^3,
@@ -78,7 +78,8 @@ ZooMizer_coupled <- function(ID, tmax = 1000, effort = 0) {
                                 gamma = 1280 * temp_eff, #takes care of temp effect on PredRate and Encounter
                                 # f0 = 0.6,
                                 # h = 10^50,
-                                R_factor = 1.01, #RMax = RFactor * RDI, default 4. Note RDI 
+                                # R_factor = 1.01, #RMax = RFactor * RDI, default 4. Note RDI 
+                                reproduction_level = 1/R_factor,
                                 ks = 0, #set metabolism to zero
                                 ext_mort_prop = 0, #currently zeroed since this is fitted. No need for temp effect here, calculates from PredMort
                                 knife_edge_size = 10  # min size for fishing

--- a/ZooMizerResourceFunctions.R
+++ b/ZooMizerResourceFunctions.R
@@ -777,6 +777,11 @@ new_emptyParams <- function(species_params,
   # Should Z0, rrPP and ccPP have names (species names etc)?
   params <- new(
     "MizerParams",
+    metadata = list(),
+    mizer_version = packageVersion("mizer"),
+    extensions = vector(mode = "character"),
+    time_created = lubridate::now(),
+    time_modified = lubridate::now(),
     w = w,
     dw = dw,
     w_full = w_full,

--- a/ZooMizerResourceFunctions.R
+++ b/ZooMizerResourceFunctions.R
@@ -91,7 +91,7 @@ setZooMizerConstants <- function(params, Groups, sst){
   
   #SearchVol <- readRDS("data/SearchVol.rds")
   
-  params <- setExtMort(params, z0 = M_sb)
+  params <- setExtMort(params, ext_mort = M_sb)
   params <- setSearchVolume(params, search_vol = SearchVol)
   params <- setPredKernel(params, pred_kernel)
   
@@ -502,7 +502,7 @@ new_newMultispeciesParams <- function(
   metab = NULL,
   p = 0.7,
   # setExtMort
-  z0 = NULL,
+  ext_mort = NULL, # z0 = NULL,
   z0pre = 0.6,
   z0exp = n - 1,
   # setReproduction
@@ -562,7 +562,7 @@ new_newMultispeciesParams <- function(
               # setMetabolicRate()
               metab = metab,
               # setExtMort
-              z0 = z0,
+              ext_mort = ext_mort,
               z0pre = z0pre,
               z0exp = z0exp,
               # setReproduction

--- a/uncoupledmodel.R
+++ b/uncoupledmodel.R
@@ -90,7 +90,7 @@ setZooMizerConstants <- function(params, Groups, sst){
   
   #SearchVol <- readRDS("data/SearchVol.rds")
   
-  params <- setExtMort(params, z0 = M_sb)
+  params <- setExtMort(params, ext_mort = M_sb)
   params <- setSearchVolume(params, search_vol = SearchVol)
   params <- setPredKernel(params, pred_kernel)
 


### PR DESCRIPTION
Apologies that this might be a little messy. I accidentally pushed the changes directly to patricksykes/ZooMizer/master. I then reverted the changes and am now opening a pull request.

This is a quick a dirty update to show you how to get it working for 2.3.0. It will likely break anything <2.3.0 but we all should probably upgrade anyway.

* I have updated the `mizerParams` function (why do we need a whole new function for this? Can't we use Mizer's `new` function for `MizerParams`  and then update with our changes?).   
* `R_factor` is deprecated. The instruction from Mizer was to change `R_factor` to `reproduction_level = 1/R_factor`
* `z0` is also deprecated in favour of `ext_mort`.